### PR TITLE
Refine type hints for Python 3.11

### DIFF
--- a/src/estv/devices/camera_stream.py
+++ b/src/estv/devices/camera_stream.py
@@ -3,6 +3,7 @@
 import time
 
 import cv2
+import numpy as np
 from PySide6.QtCore import QThread, Signal, Slot
 from PySide6.QtGui import QImage
 
@@ -12,7 +13,7 @@ MAX_LONG_SIDE_LENGTH = 640  # 長辺の最大サイズ
 CAPTURE_FPS = 30 # 最大フレームレート
 
 
-def resize_if_needed(frame, max_length):
+def resize_if_needed(frame: np.ndarray, max_length: int) -> np.ndarray:
     """長辺がmax_lengthを超える場合のみリサイズして返す。"""
     h, w = frame.shape[:2]
     if max(w, h) > max_length:

--- a/src/estv/devices/camera_stream_manager.py
+++ b/src/estv/devices/camera_stream_manager.py
@@ -16,7 +16,7 @@ class CameraStreamManager(QObject):
     q_image_ready = Signal(int, object)
 
 
-    def __init__(self, auto_restart: bool = False, restart_delay_ms: int = 2000):
+    def __init__(self, auto_restart: bool = False, restart_delay_ms: int = 2000) -> None:
         super().__init__()
 
         # --- ストリームを保持する辞書
@@ -33,7 +33,7 @@ class CameraStreamManager(QObject):
         self._lock = threading.Lock()
 
 
-    def start_camera(self, device_id: int):
+    def start_camera(self, device_id: int) -> None:
         """指定したデバイスIDのカメラストリームを開始する。"""
         with self._lock:
             if device_id in self._streams:
@@ -49,7 +49,7 @@ class CameraStreamManager(QObject):
         self.streams_updated.emit()
 
 
-    def stop_camera(self, device_id: int):
+    def stop_camera(self, device_id: int) -> None:
         """指定したデバイスIDのカメラストリームを停止しクリーンアップする。"""
         with self._lock:
             stream = self._streams.get(device_id)
@@ -63,7 +63,7 @@ class CameraStreamManager(QObject):
         self.cleanup_stream(device_id)
 
 
-    def stop_all(self):
+    def stop_all(self) -> None:
         """全てのカメラストリームを停止する。"""
         for device_id in self.running_device_ids():
             self.stop_camera(device_id)
@@ -75,7 +75,7 @@ class CameraStreamManager(QObject):
         self.stop_all()
 
 
-    def handle_error(self, device_id: int, msg: str):
+    def handle_error(self, device_id: int, msg: str) -> None:
         """カメラストリームのエラーを処理する。"""
         print(f"[Camera {device_id}] Error: {msg}")
         with self._lock:
@@ -87,7 +87,7 @@ class CameraStreamManager(QObject):
             self._pending_restart.add(device_id)
 
 
-    def cleanup_stream(self, device_id: int):
+    def cleanup_stream(self, device_id: int) -> None:
         """指定したデバイスIDのカメラストリームをクリーンアップする。"""
         with self._lock:
             if device_id in self._streams:

--- a/src/estv/gui/camera_preview_window.py
+++ b/src/estv/gui/camera_preview_window.py
@@ -1,8 +1,11 @@
 # estv/gui/camera_preview_window.py
 
-from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QPushButton
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QPushButton, QWidget
 from PySide6.QtCore import Qt
-from PySide6.QtGui import QPixmap
+from PySide6.QtGui import QPixmap, QImage, QCloseEvent
+from collections.abc import Callable
+
+from estv.devices.camera_stream_manager import CameraStreamManager
 
 from estv.gui.style_constants import TEXT_COLOR, BACKGROUND_COLOR
 
@@ -10,7 +13,13 @@ from estv.gui.style_constants import TEXT_COLOR, BACKGROUND_COLOR
 class CameraPreviewWindow(QDialog):
     """カメラのプレビューウィンドウ。"""
 
-    def __init__(self, camera_stream_manager, device_id=0, parent=None, on_closed=None):
+    def __init__(
+        self,
+        camera_stream_manager: CameraStreamManager,
+        device_id: int = 0,
+        parent: QWidget | None = None,
+        on_closed: Callable[[int], None] | None = None,
+    ) -> None:
         """コンストラクタ。"""
         super().__init__(parent)
         self.setWindowTitle("ESTV - カメラプレビュー")
@@ -45,7 +54,7 @@ class CameraPreviewWindow(QDialog):
         self.camera_stream_manager.q_image_ready.connect(self._on_image_ready)
 
 
-    def _on_image_ready(self, device_id, qimg):
+    def _on_image_ready(self, device_id: int, qimg: QImage) -> None:
         """カメラからの映像が準備できたときに呼び出される。"""
         if device_id != self.device_id:
             return
@@ -57,7 +66,7 @@ class CameraPreviewWindow(QDialog):
         ))
 
 
-    def closeEvent(self, event):
+    def closeEvent(self, event: QCloseEvent) -> None:
         """ウィンドウが閉じられたときの処理。"""
         self.camera_stream_manager.q_image_ready.disconnect(self._on_image_ready)
         self.camera_stream_manager.stop_camera(self.device_id)

--- a/src/estv/gui/main_window.py
+++ b/src/estv/gui/main_window.py
@@ -5,7 +5,7 @@ from PySide6.QtWidgets import (
     QAbstractItemView, QLabel
 )
 from PySide6.QtCore import Qt
-from PySide6.QtGui import QColor
+from PySide6.QtGui import QColor, QCloseEvent
 
 from estv.devices.camera_stream_manager import CameraStreamManager
 from estv.devices.media_device_manager import MediaDeviceManager
@@ -129,13 +129,13 @@ class MainWindow(QMainWindow):
                 self._camera_stream_manager.stop_camera(device_id)
 
 
-    def _on_preview_closed(self, device_id: int):
+    def _on_preview_closed(self, device_id: int) -> None:
         """プレビューウィンドウが閉じられたとき呼ばれる。"""
         if device_id in self._preview_windows:
             del self._preview_windows[device_id]
 
 
-    def closeEvent(self, event) -> None:
+    def closeEvent(self, event: QCloseEvent) -> None:
         """ウィンドウが閉じられたときの処理。"""
         for preview in list(self._preview_windows.values()):
             preview.close()


### PR DESCRIPTION
## Summary
- switch type hints to builtin generics and add missing annotations
- tighten types for PySide event handlers and device manager

## Testing
- `python -m compileall -q src`

------
https://chatgpt.com/codex/tasks/task_e_68899114e75c8329818b235b5e54524e