### PR TITLE
Fix camera order instability

### DIFF
--- a/src/estv/devices/camera_stream_manager.py
+++ b/src/estv/devices/camera_stream_manager.py
@@ -3,6 +3,7 @@
 import threading
 import warnings
 
+from collections.abc import Callable
 from PySide6.QtCore import QObject, Signal, QTimer
 
 from estv.devices.camera_stream import CameraStream
@@ -12,61 +13,73 @@ class CameraStreamManager(QObject):
     """複数のカメラストリームを管理するクラス。"""
 
     streams_updated = Signal()
-    frame_ready = Signal(int, object)
-    q_image_ready = Signal(int, object)
+    frame_ready = Signal(str, object)
+    q_image_ready = Signal(str, object)
 
 
-    def __init__(self, auto_restart: bool = False, restart_delay_ms: int = 2000) -> None:
+    def __init__(
+        self,
+        device_index_lookup: Callable[[str], int | None],
+        auto_restart: bool = False,
+        restart_delay_ms: int = 2000,
+    ) -> None:
         super().__init__()
 
         # --- ストリームを保持する辞書
-        self._streams: dict[int, CameraStream] = {}
+        self._streams: dict[str, CameraStream] = {}
+
+        # --- カメラIDからインデックスを取得する関数
+        self._device_index_lookup = device_index_lookup
 
         # --- 自動再起動設定
         self._auto_restart: bool = auto_restart
         self._restart_delay_ms: int = restart_delay_ms
 
         # --- 再起動待ちデバイス
-        self._pending_restart: set[int] = set()
+        self._pending_restart: set[str] = set()
 
         # --- 排他制御用ロック
         self._lock = threading.Lock()
 
 
-    def start_camera(self, device_id: int) -> None:
-        """指定したデバイスIDのカメラストリームを開始する。"""
+    def start_camera(self, camera_id: str) -> None:
+        """指定したカメラIDのストリームを開始する。"""
+        device_index = self._device_index_lookup(camera_id)
+        if device_index is None:
+            warnings.warn(f"Camera {camera_id} not found")
+            return
         with self._lock:
-            if device_id in self._streams:
-                warnings.warn(f"Camera {device_id} stream already running")
+            if camera_id in self._streams:
+                warnings.warn(f"Camera {camera_id} stream already running")
                 return
-            stream = CameraStream(device_id)
-            stream.frame_ready.connect(lambda frame, d=device_id: self.frame_ready.emit(d, frame))
-            stream.q_image_ready.connect(lambda qimg, d=device_id: self.q_image_ready.emit(d, qimg))
-            stream.error.connect(lambda msg, d=device_id: self.handle_error(d, msg))
-            stream.finished.connect(lambda d=device_id: self.cleanup_stream(d))
-            self._streams[device_id] = stream
+            stream = CameraStream(device_index)
+            stream.frame_ready.connect(lambda frame, c=camera_id: self.frame_ready.emit(c, frame))
+            stream.q_image_ready.connect(lambda qimg, c=camera_id: self.q_image_ready.emit(c, qimg))
+            stream.error.connect(lambda msg, c=camera_id: self.handle_error(c, msg))
+            stream.finished.connect(lambda c=camera_id: self.cleanup_stream(c))
+            self._streams[camera_id] = stream
             stream.start()
         self.streams_updated.emit()
 
 
-    def stop_camera(self, device_id: int) -> None:
-        """指定したデバイスIDのカメラストリームを停止しクリーンアップする。"""
+    def stop_camera(self, camera_id: str) -> None:
+        """指定したカメラIDのストリームを停止しクリーンアップする。"""
         with self._lock:
-            stream = self._streams.get(device_id)
+            stream = self._streams.get(camera_id)
 
         if stream is None:
-            warnings.warn(f"Camera {device_id} stream not running")
+            warnings.warn(f"Camera {camera_id} stream not running")
             return
 
         stream.stop()
         stream.wait()
-        self.cleanup_stream(device_id)
+        self.cleanup_stream(camera_id)
 
 
     def stop_all(self) -> None:
         """全てのカメラストリームを停止する。"""
-        for device_id in self.running_device_ids():
-            self.stop_camera(device_id)
+        for camera_id in self.running_device_ids():
+            self.stop_camera(camera_id)
         self.streams_updated.emit()
 
 
@@ -75,36 +88,36 @@ class CameraStreamManager(QObject):
         self.stop_all()
 
 
-    def handle_error(self, device_id: int, msg: str) -> None:
+    def handle_error(self, camera_id: str, msg: str) -> None:
         """カメラストリームのエラーを処理する。"""
-        print(f"[Camera {device_id}] Error: {msg}")
+        print(f"[Camera {camera_id}] Error: {msg}")
         with self._lock:
-            if device_id in self._streams:
-                stream = self._streams[device_id]
+            if camera_id in self._streams:
+                stream = self._streams[camera_id]
                 stream.stop()
 
         if self._auto_restart:
-            self._pending_restart.add(device_id)
+            self._pending_restart.add(camera_id)
 
 
-    def cleanup_stream(self, device_id: int) -> None:
-        """指定したデバイスIDのカメラストリームをクリーンアップする。"""
+    def cleanup_stream(self, camera_id: str) -> None:
+        """指定したカメラIDのストリームをクリーンアップする。"""
         with self._lock:
-            if device_id in self._streams:
-                stream = self._streams[device_id]
+            if camera_id in self._streams:
+                stream = self._streams[camera_id]
                 stream.deleteLater()
-                del self._streams[device_id]
+                del self._streams[camera_id]
 
-        if self._auto_restart and device_id in self._pending_restart:
-            self._pending_restart.remove(device_id)
+        if self._auto_restart and camera_id in self._pending_restart:
+            self._pending_restart.remove(camera_id)
             QTimer.singleShot(
                 self._restart_delay_ms,
-                lambda d=device_id: self.start_camera(d),
+                lambda c=camera_id: self.start_camera(c),
             )
         self.streams_updated.emit()
 
 
-    def running_device_ids(self) -> list[int]:
-        """現在起動中のカメラの device_id リストを返す。"""
+    def running_device_ids(self) -> list[str]:
+        """現在起動中のカメラIDリストを返す。"""
         with self._lock:
             return list(self._streams.keys())

--- a/src/estv/devices/media_device_manager.py
+++ b/src/estv/devices/media_device_manager.py
@@ -60,3 +60,10 @@ class MediaDeviceManager(QObject):
             bytes(dev.id()).decode("utf-8", errors="ignore"): dev.description()
             for dev in self._camera_devices
         }
+
+    def camera_index_by_id(self, camera_id: str) -> int | None:
+        """指定したカメラIDに対応する現在のインデックスを返す。"""
+        for idx, dev in enumerate(self._camera_devices):
+            if bytes(dev.id()).decode("utf-8", errors="ignore") == camera_id:
+                return idx
+        return None

--- a/src/estv/gui/camera_preview_window.py
+++ b/src/estv/gui/camera_preview_window.py
@@ -16,9 +16,9 @@ class CameraPreviewWindow(QDialog):
     def __init__(
         self,
         camera_stream_manager: CameraStreamManager,
-        device_id: int = 0,
+        device_id: str = "",
         parent: QWidget | None = None,
-        on_closed: Callable[[int], None] | None = None,
+        on_closed: Callable[[str], None] | None = None,
     ) -> None:
         """コンストラクタ。"""
         super().__init__(parent)
@@ -54,7 +54,7 @@ class CameraPreviewWindow(QDialog):
         self.camera_stream_manager.q_image_ready.connect(self._on_image_ready)
 
 
-    def _on_image_ready(self, device_id: int, qimg: QImage) -> None:
+    def _on_image_ready(self, device_id: str, qimg: QImage) -> None:
         """カメラからの映像が準備できたときに呼び出される。"""
         if device_id != self.device_id:
             return


### PR DESCRIPTION
## Summary
- track cameras by unique ID via `MediaDeviceManager.camera_index_by_id`
- connect `CameraStreamManager` using stable camera IDs
- update preview window and UI logic for new ID based operations

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68899a1201788329b00ddded68f69660