### PR TITLE
Fix reprojection error not shown after loading calibration

### DIFF
--- a/src/estv/devices/camera_calibrator.py
+++ b/src/estv/devices/camera_calibrator.py
@@ -102,7 +102,12 @@ class CameraCalibrator:
         """キャリブレーション結果を ``.npz`` ファイルへ保存する。"""
         if self._camera_matrix is None:
             raise ValueError("キャリブレーション未実施です。")
-        np.savez(str(filename), camera_matrix=self._camera_matrix, dist_coeffs=self._dist_coeffs)
+        np.savez(
+            str(filename),
+            camera_matrix=self._camera_matrix,
+            dist_coeffs=self._dist_coeffs,
+            reproj_error=self._reproj_error,
+        )
 
 
     def load(self, filename: str | Path) -> None:
@@ -110,3 +115,4 @@ class CameraCalibrator:
         data = np.load(str(filename))
         self._camera_matrix = data["camera_matrix"]
         self._dist_coeffs = data["dist_coeffs"]
+        self._reproj_error = float(data["reproj_error"]) if "reproj_error" in data else None


### PR DESCRIPTION
## Summary
- persist `CameraCalibrator`'s reprojection error when saving calibration
- restore reprojection error on load so UI can display it

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889cfa5e49c832996f12e3532401a1e