### PR TITLE
Use pathlib for calibration paths

### DIFF
--- a/src/estv/gui/camera_preview_window.py
+++ b/src/estv/gui/camera_preview_window.py
@@ -4,6 +4,7 @@
 from collections.abc import Callable
 import os
 import re
+from pathlib import Path
 
 import numpy as np
 from PySide6.QtWidgets import (
@@ -33,11 +34,11 @@ CALIB_CAPTURE_INTERVAL_MS = 500   # キャプチャ間隔 (ミリ秒)
 
 def _calib_file_path(device_id: str) -> str:
     """デバイスIDからキャリブレーションファイルパスを返す。"""
-    project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../"))
-    data_dir = os.path.join(project_root, "data")
-    os.makedirs(data_dir, exist_ok=True)
+    project_root = Path(__file__).resolve().parents[2]
+    data_dir = project_root / "data"
+    data_dir.mkdir(exist_ok=True)
     safe_id = re.sub(r"[^A-Za-z0-9._-]", "_", device_id)
-    return os.path.join(data_dir, f"calib_{safe_id}.npz")
+    return str(data_dir / f"calib_{safe_id}.npz")
 
 
 class CameraPreviewWindow(QDialog):


### PR DESCRIPTION
## Summary
- refactor `_calib_file_path` to use `pathlib.Path`
- add `Path` import

## Testing
- `pytest -q`
- `python -m compileall -q src/estv/gui/camera_preview_window.py`


------
https://chatgpt.com/codex/tasks/task_e_6889d7bb36e083299a16167bc13a5917