### PR TITLE
Add exposure and gain sliders with per-device persistence

### DIFF
--- a/src/estv/devices/camera_stream_manager.py
+++ b/src/estv/devices/camera_stream_manager.py
@@ -87,6 +87,22 @@ class CameraStreamManager(QObject):
         self.cleanup_stream(camera_id)
 
 
+    def set_exposure(self, camera_id: str, value: float) -> None:
+        """指定カメラの露出を設定する。"""
+        with self._lock:
+            stream = self._streams.get(camera_id)
+        if stream is not None:
+            stream.set_exposure(value)
+
+
+    def set_gain(self, camera_id: str, value: float) -> None:
+        """指定カメラのゲインを設定する。"""
+        with self._lock:
+            stream = self._streams.get(camera_id)
+        if stream is not None:
+            stream.set_gain(value)
+
+
     def stop_all(self) -> None:
         """実行中のすべてのカメラストリームを停止する。"""
         for camera_id in self.running_device_ids():


### PR DESCRIPTION
## Summary
- allow adjusting exposure and gain for each camera from the preview window
- remember exposure and gain settings per camera device
- wire camera streams to accept runtime exposure/gain updates

## Testing
- `python -m py_compile src/estv/gui/camera_preview_window.py src/estv/devices/camera_stream.py src/estv/devices/camera_stream_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_68918517a99c832991b3cd8d2ca14c69