### PR TITLE
Allow forced camera shutdown on main window close

### DIFF
--- a/src/estv/gui/main_window.py
+++ b/src/estv/gui/main_window.py
@@ -321,7 +321,7 @@ class MainWindow(QMainWindow):
     def closeEvent(self, event: QCloseEvent) -> None:
         """ウィンドウを閉じる際にすべてのストリームを停止する。"""
         for preview in list(self._preview_windows.values()):
-            preview.close()
+            preview.force_close()
         self._preview_windows.clear()
         self._camera_stream_manager.shutdown()
         super().closeEvent(event)


### PR DESCRIPTION
## Summary
- allow camera preview windows to bypass pose-estimation stop guard during application exit
- ensure MainWindow uses the new force_close helper when closing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68953e9b64388329ae93886796df09b6