### PR TITLE
Limit active cameras to three

### DIFF
--- a/src/estv/gui/main_window.py
+++ b/src/estv/gui/main_window.py
@@ -223,13 +223,19 @@ class MainWindow(QMainWindow):
     def _update_start_buttons_state(self) -> None:
         """行ごとの '起動／停止' ボタンの有効・無効を更新する。"""
         rows = self.camera_table.rowCount()
+        running_count = len(self._camera_stream_manager.running_device_ids())
+        max_streams = self._camera_stream_manager.max_streams
         for row in range(rows):
             btn = self.camera_table.cellWidget(row, 3)
             if btn is None:
                 continue
             running = btn.isChecked()
-            # 推定中 (_launch_enabled=False) はすべて無効化
-            btn.setEnabled(self._launch_enabled)
+            if not self._launch_enabled:
+                btn.setEnabled(False)
+            elif not running and running_count >= max_streams:
+                btn.setEnabled(False)
+            else:
+                btn.setEnabled(True)
 
 
     def _on_preview_closed(self, device_id: str) -> None:

--- a/tests/test_camera_stream_manager.py
+++ b/tests/test_camera_stream_manager.py
@@ -1,0 +1,52 @@
+import warnings
+
+import estv.devices.camera_stream_manager as mgr_module
+from estv.devices.camera_stream_manager import CameraStreamManager
+
+
+class DummySignal:
+    def connect(self, *args, **kwargs):
+        pass
+
+    def emit(self, *args, **kwargs):
+        pass
+
+
+class DummyStream:
+    def __init__(self, device_index):
+        self.frame_ready = DummySignal()
+        self.q_image_ready = DummySignal()
+        self.error = DummySignal()
+        self.finished = DummySignal()
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+    def wait(self):
+        pass
+
+    def deleteLater(self):
+        pass
+
+
+def test_cannot_start_more_than_three_cameras(monkeypatch):
+    # Replace CameraStream with dummy implementation to avoid hardware access
+    monkeypatch.setattr(mgr_module, "CameraStream", DummyStream)
+
+    # Simple lookup that returns integer index for given id
+    manager = CameraStreamManager(lambda cid: int(cid))
+
+    manager.start_camera("0")
+    manager.start_camera("1")
+    manager.start_camera("2")
+
+    assert len(manager.running_device_ids()) == 3
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        manager.start_camera("3")
+        assert len(manager.running_device_ids()) == 3
+        assert any("Cannot start" in str(warn.message) for warn in w)


### PR DESCRIPTION
## Summary
- Add configurable maximum camera limit (default 3) to `CameraStreamManager`
- Update main window buttons to disable starting more than allowed cameras
- Add unit test verifying the camera start limit

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68955560ed90832988f4a9e40e5a71ab