### PR TITLE
print出力をloggingに統一

### DIFF
--- a/scripts/chessboard_generator.py
+++ b/scripts/chessboard_generator.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import logging
 import numpy as np
 from reportlab.lib.units import mm
 from reportlab.pdfgen import canvas
@@ -9,6 +10,7 @@ from PIL import Image
 # --- 定数
 SCRIPT_DIR = Path(__file__).resolve().parent
 IMAGES_DIR = SCRIPT_DIR.parent / "images"
+logger = logging.getLogger(__name__)
 
 
 def mm_to_px(mm: float, dpi: int) -> int:
@@ -68,7 +70,7 @@ def main(
 
     # --- PNG保存
     Image.fromarray(canvas_img).save(out_path, format="PNG", compress_level=0, dpi=(dpi, dpi))
-    print(f"保存完了: '{out_path}' ({canvas_w}×{canvas_h}px @{dpi}dpi)")
+    logger.info("保存完了: '%s' (%d×%dpx @%ddpi)", out_path, canvas_w, canvas_h, dpi)
 
     # --- PDF保存
     # Pillowで一時保存したPNG画像をreportlabでA4に等倍貼り付け
@@ -85,10 +87,11 @@ def main(
     )
     c.showPage()
     c.save()
-    print(f"保存完了: '{out_pdf}' ({a4_w_mm}mm×{a4_h_mm}mm)")
+    logger.info("保存完了: '%s' (%smm×%smm)", out_pdf, a4_w_mm, a4_h_mm)
 
     return canvas_w, canvas_h
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
     main()

--- a/src/estv/devices/camera_stream_manager.py
+++ b/src/estv/devices/camera_stream_manager.py
@@ -1,6 +1,7 @@
 # estv/devices/camera_stream_manager.py
 
 from collections.abc import Callable
+import logging
 import threading
 import warnings
 
@@ -11,6 +12,9 @@ from PySide6.QtCore import (
 )
 
 from estv.devices.camera_stream import CameraStream
+
+
+logger = logging.getLogger(__name__)
 
 
 class CameraStreamManager(QObject):
@@ -137,7 +141,7 @@ class CameraStreamManager(QObject):
 
     def handle_error(self, camera_id: str, msg: str) -> None:
         """``camera_id`` のストリームでエラーが発生した際の処理を行う。"""
-        print(f"[Camera {camera_id}] Error: {msg}")
+        logger.error("[Camera %s] Error: %s", camera_id, msg)
         with self._lock:
             if camera_id in self._streams:
                 stream = self._streams[camera_id]

--- a/src/estv/gui/camera_preview_window.py
+++ b/src/estv/gui/camera_preview_window.py
@@ -4,6 +4,7 @@
 from collections.abc import Callable
 from filelock import FileLock
 import json
+import logging
 import os
 from pathlib import Path
 import re
@@ -46,6 +47,9 @@ from estv.gui.style_constants import (
     TEXT_COLOR,
     WARNING_COLOR,
 )
+
+
+logger = logging.getLogger(__name__)
 
 
 # --- 定数
@@ -155,7 +159,7 @@ class CameraPreviewWindow(QDialog):
                 self._exposure_value = int(data.get("exposure", 0))
                 self._brightness_value = int(data.get("brightness", 0))
             except Exception as e:
-                print(f"カメラ設定読み込み失敗: {e}")
+                logger.error("カメラ設定読み込み失敗: %s", e)
 
         # --- UI構成
         # --- Preview グループ
@@ -242,7 +246,7 @@ class CameraPreviewWindow(QDialog):
                 self.progress_bar_value_on_load = True
                 self.progress_bar.setValue(self.progress_bar.maximum())
             except Exception as e:
-                print(f"キャリブレーションパラメータ読み込み失敗: {e}")
+                logger.error("キャリブレーションパラメータ読み込み失敗: %s", e)
                 self.progress_bar_value_on_load = False
         else:
             self.progress_bar_value_on_load = False
@@ -341,7 +345,7 @@ class CameraPreviewWindow(QDialog):
                 with open(settings_path, "w", encoding="utf-8") as f:
                     json.dump(data, f)
         except Exception as e:
-            print(f"カメラ設定保存失敗: {e}")
+            logger.error("カメラ設定保存失敗: %s", e)
 
 
     def _on_calib_toggle(self, checked: bool) -> None:
@@ -385,7 +389,7 @@ class CameraPreviewWindow(QDialog):
                 # --- プロジェクトルート直下のdata/に保存
                 calib_path = _calib_file_path(self.device_id)
                 self.calibrator.save(calib_path)
-                print(f"キャリブレーションパラメータを保存: {calib_path}")
+                logger.info("キャリブレーションパラメータを保存: %s", calib_path)
             except Exception as e:
                 self.status_label.setStyleSheet(f"color: {WARNING_COLOR};")
                 self.status_label.setText(f"キャリブレーション失敗: {str(e)}")
@@ -407,7 +411,7 @@ class CameraPreviewWindow(QDialog):
                     self.calibration_done = True
                     self.progress_bar.setValue(self.progress_bar.maximum())
                 except Exception as e:
-                    print(f"キャリブレーションパラメータ読み込み失敗: {e}")
+                    logger.error("キャリブレーションパラメータ読み込み失敗: %s", e)
                     self.calibration_done = False
                     self.progress_bar.setValue(0)
             else:


### PR DESCRIPTION
## Summary
- print出力をloggingに置き換え
- カメラプレビューとストリーム管理でログ出力を追加
- チェスボード生成スクリプトで保存メッセージをログ化

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689564c656648329aad27701dfc4b486